### PR TITLE
Update merged profile paths and subproject dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - run: lein deps
       - run: lein check
       - run: lein with-profile +ci test2junit
+      - run: rm -r ~/.m2/repository/lein-monolith
       - store_test_results:
           path: test-results
       - save_cache:

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ The plugin also provides the `deps-on` task to query which subprojects have a
 certain dependency:
 
 ```
-lein monolith deps-on example/lib-b
+lein monolith deps-on lib-b
 ```
 
 Or you can go the other way with `deps-of` to find the subprojects which a
 certain project depends on:
 
 ```
-lein monolith deps-of example/app-a
+lein monolith deps-of app-a
 ```
 
 ### Subproject Iteration

--- a/doc/config.md
+++ b/doc/config.md
@@ -31,3 +31,9 @@ generated build artifacts for the subprojects. The primary examples of these are
 key in the metaproject called `:inherit-leaky`, which follows the format of
 `:inherit` above. Properties in this profile will be included in the built JAR
 and pom files for the subproject.
+
+Lastly, `lein-monolith` supports inheriting unprocessed values, via
+`:inherit-raw` and `:inherit-leaky-raw`. These are of particular use when
+inheriting paths, as Leiningen absolutizes paths upon processing a project map.
+By using raw inheritance, you can safely inherit paths, e.g. `:test-paths` or
+`:source-paths`.

--- a/example/apps/app-a/project.clj
+++ b/example/apps/app-a/project.clj
@@ -1,4 +1,4 @@
-(defproject example/app-a "MONOLITH-SNAPSHOT"
+(defproject lein-monolith.example/app-a "MONOLITH-SNAPSHOT"
   :description "Example project with internal and external dependencies."
   :monolith/inherit true
   :deployable true
@@ -6,8 +6,8 @@
   :dependencies
   [[org.clojure/clojure "1.10.1"]
    [commons-io "2.5"]
-   [example/lib-a "MONOLITH-SNAPSHOT"]
-   [example/lib-b "MONOLITH-SNAPSHOT"]]
+   [lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]
+   [lein-monolith.example/lib-b "MONOLITH-SNAPSHOT"]]
 
   :profiles
   {:shared {:source-paths ["bench"]}

--- a/example/libs/lib-a/project.clj
+++ b/example/libs/lib-a/project.clj
@@ -1,4 +1,4 @@
-(defproject example/lib-a "MONOLITH-SNAPSHOT"
+(defproject lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"
   :description "Example library with no internal dependencies."
   :monolith/inherit true
 

--- a/example/libs/lib-b/project.clj
+++ b/example/libs/lib-b/project.clj
@@ -1,7 +1,7 @@
-(defproject example/lib-b "MONOLITH-SNAPSHOT"
+(defproject lein-monolith.example/lib-b "MONOLITH-SNAPSHOT"
   :description "Example lib depending on lib-a."
   :monolith/inherit [:aliases]
 
   :dependencies
   [[org.clojure/clojure "1.10.1"]
-   [example/lib-a "MONOLITH-SNAPSHOT"]])
+   [lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]])

--- a/example/project.clj
+++ b/example/project.clj
@@ -1,4 +1,4 @@
-(defproject example/all "MONOLITH"
+(defproject lein-monolith.example/all "MONOLITH"
   :description "Overarching example project."
 
   :aliases
@@ -19,15 +19,28 @@
   {:unit (complement :integration)
    :integration :integration}
 
+  :test-paths ^:replace
+  ["test/unit"
+   "test/integration"]
+
+  :compile-path
+  "%s/compiled"
+
   :monolith
   {:inherit
    [:aliases
     :test-selectors
     :env]
 
+   :inherit-raw
+   [:test-paths]
+
    :inherit-leaky
    [:repositories
     :managed-dependencies]
+
+   :inherit-leaky-raw
+   [:compile-path]
 
    :project-selectors
    {:deployable :deployable

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -230,7 +230,7 @@
   absolutizes any paths in the subproject that may be relative."
   [monolith [_project-name subproject]]
   (-> subproject
-      (project/project-with-profiles (:profiles subproject))
+      (project/project-with-profiles)
       (project/init-profiles (:active-profiles (meta monolith)))
       (middleware monolith)
       (project/absolutize-paths)))

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -10,6 +10,32 @@
 
 ;; ## Profile Generation
 
+(def profile-config
+  "Configuration for inherited profiles. Structured as a vector of pairs to
+  maintain ordering. The ordering is significant as the info command consumes
+  this configuration directly, and providing deterministic output ordering is
+  desirable."
+  [[:monolith/inherited
+    {:inherit-key :inherit
+     :subproject-key :monolith/inherit}]
+
+   [:monolith/inherited-raw
+    {:raw? true
+     :inherit-key :inherit-raw
+     :subproject-key :monolith/inherit-raw}]
+
+   [:monolith/leaky
+    {:leaky? true
+     :inherit-key :inherit-leaky
+     :subproject-key :monolith/inherit-leaky}]
+
+   [:monolith/leaky-raw
+    {:leaky? true
+     :raw? true
+     :inherit-key :inherit-leaky-raw
+     :subproject-key :monolith/inherit-leaky-raw}]])
+
+
 (defn- subproject-dependencies
   "Given a map of internal projects, return a vector of dependency coordinates
   for the subprojects."
@@ -17,63 +43,58 @@
   (mapv #(vector (key %) (:version (val %))) subprojects))
 
 
-(defn- add-profile-paths
-  "Update a profile paths entry by adding the absolute paths from the given
-  project. Returns the updated profile."
-  [profile project k]
-  (update profile k into
-          (map (partial str (:root project) "/")
-               (get project k))))
+(defn- maybe-mark-leaky
+  "Add ^:leaky metadata to a profile if it is of the leaky type."
+  [profile {:keys [leaky?]}]
+  (if leaky?
+    (vary-meta profile assoc :leaky true)
+    profile))
 
 
-(defn merged-profile
-  "Constructs a profile map containing merged (re)source and test paths."
-  [subprojects]
-  (reduce-kv
-    (fn [profile _ project]
-      (-> profile
-          (add-profile-paths project :resource-paths)
-          (add-profile-paths project :source-paths)
-          (add-profile-paths project :test-paths)))
-    {:dependencies (subproject-dependencies subprojects)
-     :resource-paths []
-     :source-paths []
-     :test-paths []}
-    subprojects))
+(defn- choose-inheritance-source
+  "Choose either the initialized monolith or its raw representation for use when
+  building an inherited profile."
+  [monolith {:keys [raw?]}]
+  (if raw?
+    (:monolith/raw (meta monolith))
+    monolith))
 
 
 (defn- select-inherited-properties
-  "Constructs a profile map containing the given inherited properties from the
-  monolith project map."
-  [monolith base-properties setting]
-  (cond
-    ;; Don't inherit anything
-    (not setting)
-    nil
+  "Constructs a profile map containing the inherited properties from a parent
+  project map."
+  [monolith base-properties subproject subproject-key]
+  (let [default (boolean (:monolith/inherit subproject))
+        setting (subproject-key subproject default)]
+    (cond
+      ;; Don't inherit anything
+      (not setting)
+      nil
 
-    ;; Inherit the base properties specified in the parent.
-    (true? setting)
-    (select-keys monolith base-properties)
+      ;; Inherit the base properties specified in the parent.
+      (true? setting)
+      (select-keys monolith base-properties)
 
-    ;; Provide additional properties to inherit, or replace if metadata is set.
-    (vector? setting)
-    (select-keys monolith
-                 (if (:replace (meta setting))
-                   setting
-                   (distinct (concat base-properties setting))))
+      ;; Provide additional properties to inherit, or replace if metadata is set.
+      (vector? setting)
+      (select-keys monolith
+                   (if (:replace (meta setting))
+                     setting
+                     (distinct (concat base-properties setting))))
 
-    :else
-    (throw (ex-info (str "Unknown value type for monolith inherit setting: "
-                         (pr-str setting))
-                    {:inherit setting}))))
+      :else
+      (throw (ex-info (str "Unknown value type for monolith inherit setting: "
+                           (pr-str setting))
+                      {:inherit setting
+                       :subproject-key subproject-key})))))
 
 
 (defn- inherited-profile
   "Constructs a profile map containing the inherited properties from a parent
   project map."
-  [monolith inherit-key setting]
+  [monolith subproject {:keys [inherit-key subproject-key]}]
   (when-let [base-properties (get-in monolith [:monolith inherit-key])]
-    (when-let [profile (select-inherited-properties monolith base-properties setting)]
+    (when-let [profile (select-inherited-properties monolith base-properties subproject subproject-key)]
       (when (contains? profile :profiles)
         (lein/warn "WARN: nested profiles cannot be inherited; ignoring :profiles in monolith" inherit-key))
       (dissoc profile :profiles))))
@@ -82,16 +103,16 @@
 (defn build-inherited-profiles
   "Returns a map from profile keys to inherited profile maps."
   [monolith subproject]
-  (let [inherit-profile (inherited-profile
-                          monolith :inherit
-                          (:monolith/inherit subproject))
-        leaky-profile (inherited-profile
-                        monolith :inherit-leaky
-                        (:monolith/leaky subproject (boolean (:monolith/inherit subproject))))]
-    (cond-> nil
-      inherit-profile (assoc :monolith/inherited inherit-profile)
-      leaky-profile (assoc :monolith/leaky (vary-meta leaky-profile assoc :leaky true)))))
-
+  (reduce
+    (fn [acc [key config]]
+      (let [profile (some-> (choose-inheritance-source monolith config)
+                            (inherited-profile subproject config)
+                            (maybe-mark-leaky config))]
+        (if profile
+          (assoc acc key profile)
+          acc)))
+    nil
+    profile-config))
 
 
 ;; ## Profile Utilities
@@ -129,26 +150,29 @@
       (activate-profile profile-key)))
 
 
-
 ;; ## Plugin Middleware
 
 (defn middleware
   "Handles inherited properties in monolith subprojects by looking for the
   `:monolith/inherit` key."
-  [project]
-  (if (:monolith/inherit project)
-    ; Monolith subproject, add inherited profile.
-    (if (or (profile-active? project :monolith/inherited)
-            (profile-active? project :monolith/leaky))
-      ; Already activated, return project.
-      (do (lein/debug "One or both inherited profiles are already active!")
-          project)
-      ; Find monolith metaproject and generate profile.
-      (let [monolith (config/find-monolith! project)
-            profiles (build-inherited-profiles monolith project)]
-        (reduce-kv add-active-profile project profiles)))
-    ; Normal project, don't activate.
-    project))
+  ([project]
+   (middleware project nil))
+  ([project monolith]
+   (if (:monolith/inherit project)
+     ;; Monolith subproject, add inherited profile.
+     (if (some (fn this-profile-active?
+                 [entry]
+                 (profile-active? project (first entry)))
+               profile-config)
+       ;; Already activated, return project.
+       (do (lein/debug "One or more inherited profiles are already active!")
+           project)
+       ;; Find monolith metaproject and generate profile.
+       (let [monolith (or monolith (config/find-monolith! project))
+             profiles (build-inherited-profiles monolith project)]
+         (reduce-kv add-active-profile project profiles)))
+     ;; Normal project, don't activate.
+     project)))
 
 
 (defn add-middleware
@@ -159,3 +183,41 @@
     (if (some #{mw-sym} (:middleware project))
       project
       (update project :middleware (fnil conj []) mw-sym))))
+
+
+;; ## Merged Profiles (`with-all`) Creation
+
+
+(def ^:private path-keys
+  "Project map keys for (re)source and test paths."
+  #{:resource-paths :source-paths :test-paths})
+
+
+(defn- add-profile-paths
+  "Update a profile paths entry by adding the paths from the given project.
+  Returns the updated profile."
+  [project profile k]
+  (update profile k (fn combine-colls
+                      [coll]
+                      (-> coll
+                          set
+                          (into (get project k))
+                          (vary-meta assoc :replace true)))))
+
+
+(defn merged-profile
+  "Constructs a profile map containing merged (re)source and test paths."
+  [monolith subprojects]
+  (let [profile
+        (reduce-kv
+          (fn [profile _project-name subproject]
+            (let [with-inherited-profiles (middleware subproject monolith)
+                  project (project/absolutize-paths with-inherited-profiles)]
+              (reduce (partial add-profile-paths project)
+                      profile
+                      path-keys)))
+          (select-keys monolith path-keys)
+          subprojects)]
+    (as-> profile v
+          (reduce (fn sort-paths [acc k] (update acc k sort)) v path-keys)
+          (assoc v :dependencies (subproject-dependencies subprojects)))))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -109,6 +109,13 @@
                args)))
 
 
+(defn- assoc-empty-displaceable
+  "Associate a given key with an empty, ^:displace-able version of its value,
+  meant to be suberseded by a value from an incoming profile."
+  [proj k v]
+  (assoc proj k (with-meta (empty v) {:displace true})))
+
+
 (defn ^:higher-order with-all
   "Apply the given task with a merged set of dependencies, sources, and tests
   from all the internal projects.
@@ -123,11 +130,7 @@
         [monolith subprojects] (u/load-monolith! project)
         targets (target/select monolith subprojects opts)
         profile (plugin/merged-profile monolith (select-keys subprojects targets))
-        project (reduce-kv
-                  (fn remove-replace-meta
-                    [proj k _v]
-                    (update proj k vary-meta dissoc :replace))
-                  project profile)]
+        project (reduce-kv assoc-empty-displaceable project profile)]
     (lein/apply-task
       task
       (plugin/add-active-profile project :monolith/all profile)

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -122,7 +122,12 @@
   (let [[opts [task & args]] (u/parse-kw-args target/selection-opts args)
         [monolith subprojects] (u/load-monolith! project)
         targets (target/select monolith subprojects opts)
-        profile (plugin/merged-profile (select-keys subprojects targets))]
+        profile (plugin/merged-profile monolith (select-keys subprojects targets))
+        project (reduce-kv
+                  (fn remove-replace-meta
+                    [proj k _v]
+                    (update proj k vary-meta dissoc :replace))
+                  project profile)]
     (lein/apply-task
       task
       (plugin/add-active-profile project :monolith/all profile)

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -28,11 +28,11 @@ test_monolith() {
 test_monolith info
 test_monolith lint
 test_monolith deps
-test_monolith deps-of example/app-a
-test_monolith deps-on example/lib-a
-test_monolith with-all pprint :dependencies :source-paths
+test_monolith deps-of app-a
+test_monolith deps-on lib-a
+test_monolith with-all pprint :dependencies :source-paths :test-paths
 test_monolith each pprint :version
-test_monolith each :in lib-a pprint :root
+test_monolith each :in lib-a pprint :root :compile-path
 test_monolith each :upstream-of lib-b pprint :version
 test_monolith each :downstream-of lib-a pprint :name
 test_monolith each :parallel 3 :report :endure pprint :group

--- a/test/lein_monolith/monolith_test.clj
+++ b/test/lein_monolith/monolith_test.clj
@@ -41,17 +41,23 @@
 
 
 (deftest with-all-test
-  (is (= ["apps/app-a/resources"
-          "dev-resources"
+  (is (= [['lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]
+          ['lein-monolith.example/app-a "MONOLITH-SNAPSHOT"]
+          ['lein-monolith.example/lib-b "MONOLITH-SNAPSHOT"]]
+         (read-pprint-output :dependencies)))
+
+  (is (= ["apps/app-a/dev-resources"
+          "apps/app-a/resources"
+          "libs/lib-a/dev-resources"
           "libs/lib-a/resources"
-          "libs/lib-b/resources"
-          "resources"]
+          "libs/lib-b/dev-resources"
+          "libs/lib-b/resources"]
          (relativize-pprint-output :resource-paths)))
 
-  (is (= ["apps/app-a/src"
+  (is (= ["apps/app-a/bench"
+          "apps/app-a/src"
           "libs/lib-a/src"
-          "libs/lib-b/src"
-          "src"]
+          "libs/lib-b/src"]
          (relativize-pprint-output :source-paths)))
 
   (is (= ["apps/app-a/test/integration"
@@ -59,7 +65,5 @@
           "libs/lib-a/test/integration"
           "libs/lib-a/test/unit"
           "libs/lib-b/test/integration"
-          "libs/lib-b/test/unit"
-          "test/integration"
-          "test/unit"]
+          "libs/lib-b/test/unit"]
          (relativize-pprint-output :test-paths))))

--- a/test/lein_monolith/monolith_test.clj
+++ b/test/lein_monolith/monolith_test.clj
@@ -1,0 +1,65 @@
+(ns lein-monolith.monolith-test
+  (:require
+    [clojure.java.io :as io]
+    [clojure.test :refer [deftest is]]
+    [lein-monolith.test-utils :refer [use-example-project read-example-project]]
+    [leiningen.monolith :as monolith]))
+
+
+(use-example-project)
+
+
+(defn- absolute-path
+  "Return an absolute java.nio.file.Path for the given file-ish input."
+  [x]
+  (.. (io/as-file x) toPath toAbsolutePath))
+
+
+(defn- read-pprint-output
+  "Runs lein pprint with the given key path using the :monolith/all profile."
+  [& ks]
+  (->> (map str ks)
+       (apply vector "pprint")
+       (monolith/with-all (read-example-project))
+       with-out-str
+       read-string))
+
+
+(defn- relativize-path
+  "Convert absolute paths to paths relative to the example project."
+  [path]
+  (str (.relativize (absolute-path "example") (absolute-path path))))
+
+
+(defn- relativize-pprint-output
+  "Read pprint output and convert absolute paths to paths relative to the
+  example project."
+  [& ks]
+  (->> ks
+       (apply read-pprint-output)
+       (map relativize-path)))
+
+
+(deftest with-all-test
+  (is (= ["apps/app-a/resources"
+          "dev-resources"
+          "libs/lib-a/resources"
+          "libs/lib-b/resources"
+          "resources"]
+         (relativize-pprint-output :resource-paths)))
+
+  (is (= ["apps/app-a/src"
+          "libs/lib-a/src"
+          "libs/lib-b/src"
+          "src"]
+         (relativize-pprint-output :source-paths)))
+
+  (is (= ["apps/app-a/test/integration"
+          "apps/app-a/test/unit"
+          "libs/lib-a/test/integration"
+          "libs/lib-a/test/unit"
+          "libs/lib-b/test/integration"
+          "libs/lib-b/test/unit"
+          "test/integration"
+          "test/unit"]
+         (relativize-pprint-output :test-paths))))

--- a/test/lein_monolith/plugin_test.clj
+++ b/test/lein_monolith/plugin_test.clj
@@ -1,0 +1,32 @@
+(ns lein-monolith.plugin-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [lein-monolith.config :as config]
+    [lein-monolith.plugin :as plugin]
+    [lein-monolith.test-utils :refer [use-example-project read-example-project]]
+    [leiningen.core.project :as project]))
+
+
+(use-example-project)
+
+
+(deftest build-inherited-profiles-test
+  (let [monolith (config/find-monolith! (read-example-project))
+        subproject (project/read "example/apps/app-a/project.clj")
+        profiles (plugin/build-inherited-profiles monolith subproject)]
+    (is (= #{:monolith/inherited
+             :monolith/inherited-raw
+             :monolith/leaky
+             :monolith/leaky-raw}
+           (set (keys profiles))))
+    (is (= {:test-paths ["test/unit" "test/integration"]}
+           (:monolith/inherited-raw profiles)))
+    (is (= {:repositories
+            [["central"
+              {:url "https://repo1.maven.org/maven2/"
+               :snapshots false}]
+             ["clojars" {:url "https://repo.clojars.org/"}]]
+            :managed-dependencies [['amperity/greenlight "0.6.0"]]}
+           (:monolith/leaky profiles)))
+    (is (= {:compile-path "%s/compiled"}
+           (:monolith/leaky-raw profiles)))))

--- a/test/lein_monolith/test_utils.clj
+++ b/test/lein_monolith/test_utils.clj
@@ -1,0 +1,47 @@
+(ns lein-monolith.test-utils
+  (:require
+    [clojure.test :refer [use-fixtures]]
+    [lein-monolith.task.each :as each]
+    [lein-monolith.task.util :as u]
+    [leiningen.core.main :as lein]
+    [leiningen.core.project :as project]
+    [leiningen.deps :as deps]
+    [leiningen.install :as install])
+  (:import
+    (java.io
+      StringWriter)))
+
+
+(defn read-example-project
+  "Read in the example monolith project."
+  []
+  (project/read "example/project.clj"))
+
+
+(defn prepare-example-project
+  "Prepare the example project by installing the source version of
+  lein-monolith, fetching the example project's dependencies, and installing all
+  of the example project's subprojects."
+  []
+  (let [out (StringWriter.)]
+    (try
+      (binding [lein/*exit-process?* false
+                *out* out
+                *err* out]
+        (install/install (project/read "project.clj"))
+        (let [[monolith subprojects] (u/load-monolith! (read-example-project))]
+          (deps/deps monolith)
+          (doseq [[_project-name project] subprojects]
+            (each/run-tasks project {} ["install"]))))
+      (catch Exception e
+        (.println *err* (str out))
+        (throw e)))))
+
+
+(defn use-example-project
+  "Adds a fixture that ensures that the example project is completely set up so
+  monolith tasks can be run against it for testing."
+  []
+  (use-fixtures :once (fn [f]
+                        (prepare-example-project)
+                        (f))))


### PR DESCRIPTION
* Don't include monolith project paths or dependencies
* Ensure active profiles are activated in subprojects before reading and absolutizing paths